### PR TITLE
KAPS-3152: Add changes to use v2 API with App name

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -5,12 +5,6 @@ branding:
   icon: activity
   color: purple
 inputs:
-  organization_id:
-    description: "The unique identifier of the organization"
-    required: true
-  environment_id:
-    description: "The unique identifier of the environment"
-    required: true
   application_name:
     description: "The name of the application"
     required: true
@@ -35,8 +29,6 @@ runs:
   using: "docker"
   image: "Dockerfile"
   args:
-    - ${{ inputs.organization_id}}
-    - ${{ inputs.environment_id}}
     - ${{ inputs.application_name}}
     - ${{ inputs.image_tag}}
     - ${{ inputs.pre_deploy_image_tag}}

--- a/action.yaml
+++ b/action.yaml
@@ -11,8 +11,8 @@ inputs:
   environment_id:
     description: "The unique identifier of the environment"
     required: true
-  application_id:
-    description: "The unique identifier of the application"
+  application_name:
+    description: "The name of the application"
     required: true
   image_tag:
     description: "The image tag you want to deploy"
@@ -37,7 +37,7 @@ runs:
   args:
     - ${{ inputs.organization_id}}
     - ${{ inputs.environment_id}}
-    - ${{ inputs.application_id}}
+    - ${{ inputs.application_name}}
     - ${{ inputs.image_tag}}
     - ${{ inputs.pre_deploy_image_tag}}
     - ${{ inputs.kapstan_api_key}}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 
-kapstan_api_base_url="https://api.kapstan.io/external/v2"
+kapstan_api_base_url="https://api.kapstan.io/v2/external"
 filePath="/tmp/response.txt"
 
 # Function to trigger application deployment
 deployment_application() {
-  deployment_trigger_url="$kapstan_api_base_url/organizations/${INPUT_ORGANIZATION_ID}/workspaces/$INPUT_ENVIRONMENT_ID/applications/${INPUT_APPLICATION_NAME}/deploy"
+  deployment_trigger_url="$kapstan_api_base_url/applications/${INPUT_APPLICATION_NAME}/deploy"
 
   # Build the JSON request body
   request_body=$(cat <<EOF
@@ -40,7 +40,7 @@ EOF
 
 
 get_deployment_status(){
-  deployment_status_url="$kapstan_api_base_url/organizations/${INPUT_ORGANIZATION_ID}/workspaces/$INPUT_ENVIRONMENT_ID/applications/${INPUT_APPLICATION_NAME}/deployments/${DEPLOYMENT_ID}"
+  deployment_status_url="$kapstan_api_base_url/applications/${INPUT_APPLICATION_NAME}/deployments/${DEPLOYMENT_ID}"
   echo "API URL: $deployment_status_url"
   status_code=$(curl -sSk  -o $filePath -w "%{http_code}" "$deployment_status_url" \
   -H "Content-Type: application/json" \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 
-kapstan_api_base_url="https://api.kapstan.io/external"
+kapstan_api_base_url="https://api.kapstan.io/external/v2"
 filePath="/tmp/response.txt"
 
 # Function to trigger application deployment
 deployment_application() {
-  deployment_trigger_url="$kapstan_api_base_url/organizations/${INPUT_ORGANIZATION_ID}/workspaces/$INPUT_ENVIRONMENT_ID/applications/${INPUT_APPLICATION_ID}/deploy"
+  deployment_trigger_url="$kapstan_api_base_url/organizations/${INPUT_ORGANIZATION_ID}/workspaces/$INPUT_ENVIRONMENT_ID/applications/${INPUT_APPLICATION_NAME}/deploy"
 
   # Build the JSON request body
   request_body=$(cat <<EOF
@@ -40,7 +40,7 @@ EOF
 
 
 get_deployment_status(){
-  deployment_status_url="$kapstan_api_base_url/organizations/${INPUT_ORGANIZATION_ID}/workspaces/$INPUT_ENVIRONMENT_ID/applications/${INPUT_APPLICATION_ID}/deployments/${DEPLOYMENT_ID}"
+  deployment_status_url="$kapstan_api_base_url/organizations/${INPUT_ORGANIZATION_ID}/workspaces/$INPUT_ENVIRONMENT_ID/applications/${INPUT_APPLICATION_NAME}/deployments/${DEPLOYMENT_ID}"
   echo "API URL: $deployment_status_url"
   status_code=$(curl -sSk  -o $filePath -w "%{http_code}" "$deployment_status_url" \
   -H "Content-Type: application/json" \
@@ -65,7 +65,7 @@ check_deployment_status(){
     # keep checking if the status is completed or not, otherwise exit 1
     if [[ $DEPLOYMENT_STATUS == "STAGE_COMPLETED" ]];
     then
-        echo "KAPSTAN_DEPLOYMENT_MESSAGE='Deployment completed https://app.kapstan.io/applications/application/$INPUT_APPLICATION_ID?tab=deployment'" >> "$GITHUB_ENV"
+        echo "KAPSTAN_DEPLOYMENT_MESSAGE='Deployment completed for application: $INPUT_APPLICATION_NAME'" >> "$GITHUB_ENV"
         exit 0
     elif [[ $DEPLOYMENT_STATUS == "STAGE_FAILED" ]];
     then


### PR DESCRIPTION
Use app-name to trigger cd deployment runs, and remove org id and env id from the api endpoint.
THIS IS A BREAKING CHANGE IN API, SO NO RELEASE SHOULD HAVE THIS CHANGE UNLESS THE NEW API IS ROLLED OUT.

NOT TO BE MERGED before https://github.com/kapstan-io/root/pull/1630 is merged.