### PR TITLE
KAP-2930:Added commit details tag to GitHub Action

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -28,6 +28,9 @@ inputs:
   containers:
     description: "Array of container objects with name and imageTag. Empty tags would be omitted"
     required: false
+  commit_details:
+    description: "https://github.com/kapstan-io/shadowfax/commits/d0cb228ba5465db48b431f88c47547c72a125029"
+    required: false
 
 runs:
   using: "docker"
@@ -39,3 +42,4 @@ runs:
     - ${{ inputs.kapstan_api_key}}
     - ${{ inputs.wait_for_deployment}}
     - ${{ inputs.containers }}
+    - ${{ inputs.commit_details }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,6 +6,7 @@ INPUT_PRE_DEPLOY_IMAGE_TAG="$3"
 INPUT_KAPSTAN_API_KEY="$4"
 INPUT_WAIT_FOR_DEPLOYMENT="$5"
 INPUT_CONTAINERS_YAML="$6"
+INPUT_COMMIT_DETAILS="$7"
 
 
 kapstan_api_base_url="https://api.kapstan.io/v2/external"
@@ -22,7 +23,8 @@ deployment_application() {
   "imageTag": "$INPUT_IMAGE_TAG",
   "comment": "Deployment triggered by action ${GITHUB_EVENT_NAME} on ${GITHUB_REF_NAME} in ${GITHUB_REPOSITORY}",
   "preDeployImageTag": "$INPUT_PRE_DEPLOY_IMAGE_TAG",
-  "containersUpdate": $INPUT_CONTAINERS_JSON
+  "containersUpdate": $INPUT_CONTAINERS_JSON,
+  "commitDetails": "$INPUT_COMMIT_DETAILS"
 }
 EOF
 )


### PR DESCRIPTION
This PR adds commit details as an additional parameter in the request body for the GitHub Action workflow.

[KAP-2930]: added commit detail parameter for deployment through github action
https://kapstan.atlassian.net/browse/KAP-2930

[KAP-2930]: https://kapstan.atlassian.net/browse/KAP-2930?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ