### PR TITLE
KAP-2930: changed the decription link of commit_details parameter

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -29,7 +29,7 @@ inputs:
     description: "Array of container objects with name and imageTag. Empty tags would be omitted"
     required: false
   commit_details:
-    description: "https://github.com/kapstan-io/shadowfax/commits/d0cb228ba5465db48b431f88c47547c72a125029"
+    description: "https://github.com/kapstan-io/shadowfax/commit/d0cb228ba5465db48b431f88c47547c72a125029"
     required: false
 
 runs:


### PR DESCRIPTION
This PR changes commit details description.

[KAP-2930]: added commit detail parameter for deployment through github action
https://kapstan.atlassian.net/browse/KAP-2930

[KAP-2930]: https://kapstan.atlassian.net/browse/KAP-2930?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ